### PR TITLE
crawler/mobile: use custom agent

### DIFF
--- a/crawler/mobile.js
+++ b/crawler/mobile.js
@@ -1,9 +1,17 @@
 const cfg     = require('../core/config'),
       debug   = require('../core/debug')('crawler/mobile', true),
       request = require('request'),
-      twitter = require('../crawler/twitter');
+      twitter = require('../crawler/twitter'),
+      Agent   = require('agentkeepalive').HttpsAgent;
 
 var mobile = module.exports = {};
+
+var requestAgent = new Agent({
+    keepAlive: true,
+    maxFreeSockets: 10,
+    timeout: 20000,
+    keepAliveTimeout: 10000
+});
 
 // get returns a Promise for the content of the given URL
 // HTTPS only.
@@ -11,6 +19,7 @@ function get(url, retries) {
     return new Promise(function(resolve, reject) {
         request({
             url: url,
+            agent: requestAgent,
             timeout: cfg.twitter.timeout
         }, function (err, resp, body) {
             if (!!err) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/Rostlab/JS16_ProjectD_Group4#readme",
   "dependencies": {
     "Sentimental": "^1.0.1",
+    "agentkeepalive": "^2.0.5",
     "express": "^4.13.4",
     "express-handlebars": "^3.0.0",
     "mongoose": "^4.4.6",


### PR DESCRIPTION
- uses keep-alive
- shorter timeouts

Might fix #51 and should improve performance
