### PR TITLE
pkg: simplify assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ gotsent.update().then(function(res) {
 
 * [.cfg](#gotsentimental.cfg) : <code>Object</code>
 * [.cfg.extend(json)](#gotsentimental.cfg.extend)
-* [.css](#gotsentimental.css)
-* [.js](#gotsentimental.js)
+* [.css](#gotsentimental.css) : <code>string</code>
+* [.js](#gotsentimental.js) : <code>string</code>
 * [.init()](#gotsentimental.init)
 * [.shutdown()](#gotsentimental.shutdown)
 * [.update([full])](#gotsentimental.update) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -188,22 +188,14 @@ Get the most discussed [characters](#character).
 | [n] | <code>number</code> | <code>10</code> | Number of Characters to return |
 
 <a name="gotsentimental.css"></a>
-#### gotsentimental.css
-The Chart CSS file
-
-| Name | Type | Description |
-| --- | --- | --- |
-| path | <code>string</code> | Absolute path to file |
-| serve | <code>function</code> | HTTP handler to serve file |
+### gotsentimental.css : <code>string</code>
+Absolute path to the Chart CSS file.
+It should be served with e.g. [express' sendFile](http://expressjs.com/de/api.html#res.sendFile).
 
 <a name="gotsentimental.js"></a>
-#### gotsentimental.js
-The Chart JS file
-
-| Name | Type | Description |
-| --- | --- | --- |
-| path | <code>string</code> | Absolute path to file |
-| serve | <code>function</code> | HTTP handler to serve file |
+### gotsentimental.js : <code>string</code>
+Absolute path to the Chart JS file.
+It should be served with e.g. [express' sendFile](http://expressjs.com/de/api.html#res.sendFile).
 
 <a name="gotsentimental.stats"></a>
 #### gotsentimental.stats() ⇒ <code>Promise.&lt;Object&gt;</code>

--- a/core/asset.js
+++ b/core/asset.js
@@ -1,27 +1,7 @@
 "use strict";
 
-const fs    = require('fs'),
-      path  = require('path'),
-      debug = require('../core/debug')('core/config', true);
-
-function serve(p, req, res) {
-    fs.readFile(p, function (err, data) {
-        if (err) {
-            res.writeHead(404);
-            res.end(JSON.stringify(err));
-            return;
-        }
-        res.writeHead(200);
-        res.end(data);
-    });
-}
+const path  = require('path');
 
 module.exports = function(filename) {
-    var p = String(path.resolve(__dirname, '..', filename));
-    return {
-        "path": p,
-        "serve": function(req, res) {
-            serve(p, req, res);
-        }
-    };
+    return String(path.resolve(__dirname, '..', filename));
 };

--- a/example/app/app.js
+++ b/example/app/app.js
@@ -43,9 +43,13 @@ app.get('/', function(req, resp) {
     })
 });
 
-app.use('/chart.css', gotsent.css.serve);
-app.use('/chart.js', gotsent.js.serve);
-
+// serve required static files (chart.css, chart.js and CSV folder)
+app.get('/assets/chart.css', function(req,res) {
+    res.sendFile(gotsent.css);
+});
+app.get('/assets/chart.js', function(req,res) {
+    res.sendFile(gotsent.js);
+});
 const oneHour = 3600000;
 app.use('/csv', express.static(__dirname + '/csv', { maxAge: oneHour }));
 

--- a/example/app/views/chart.html
+++ b/example/app/views/chart.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <title>GoT Twitter Sentiment Analysis</title>
-    <link rel="stylesheet" href="/chart.css">
+    <link rel="stylesheet" href="/assets/chart.css">
 </head>
 <body>
     <svg id="chart" width="100%" height="480"></svg>
     <script src="/assets/d3.min.js"></script>
-    <script src="/chart.js"></script>
+    <script src="/assets/chart.js"></script>
     <script>
     var chart = characterChart(d3.select("#chart"), "/csv/{{slug}}.csv");
     d3.select(window).on('resize', chart.resize);

--- a/index.js
+++ b/index.js
@@ -221,16 +221,16 @@ pkg.mostDiscussed = function(n) {
 };
 
 /**
- * The Chart CSS file
- * @property {string}   path   Absolute path to file
- * @property {function} serve  HTTP handler to serve file
+ * Absolute path to the Chart CSS file.
+ * It should be served with e.g. express' sendFile.
+ * @type {string}
  */
 pkg.css = asset('public/chart.css');
 
 /**
- * The Chart JS file
- * @property {string}   path   Absolute path to file
- * @property {function} serve  HTTP handler to serve file
+ * Absolute path to the Chart JS file.
+ * It should be served with e.g. express' sendFile.
+ * @type {string}
  */
 pkg.js = asset('public/chart.js');
 


### PR DESCRIPTION
No one should use our HTTP handlers. They do no caching, don’t set
e-tags etc.
