### PR TITLE
Visualization Fixes #2

### DIFF
--- a/example/app/views/chart.html
+++ b/example/app/views/chart.html
@@ -1,17 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <title>GoT Twitter Sentiment Analysis</title>
     <link rel="stylesheet" href="/assets/chart.css">
 </head>
+
 <body>
     <svg id="chart" width="100%" height="480"></svg>
     <script src="/assets/d3.min.js"></script>
     <script src="/assets/chart.js"></script>
     <script>
-    var chart = characterChart(d3.select("#chart"), "/csv/{{slug}}.csv", "/csv/episodes.csv");
-    d3.select(window).on('resize', chart.resize);
+        var chart = new characterChart(d3.select("#chart"), "/csv/{{slug}}.csv");
+        d3.select(window).on('resize', chart.resize);
     </script>
 </body>
+
 </html>

--- a/example/app/views/chart.html
+++ b/example/app/views/chart.html
@@ -10,7 +10,7 @@
     <script src="/assets/d3.min.js"></script>
     <script src="/assets/chart.js"></script>
     <script>
-    var chart = characterChart(d3.select("#chart"), "/csv/{{slug}}.csv");
+    var chart = characterChart(d3.select("#chart"), "/csv/{{slug}}.csv", "/csv/episodes.csv");
     d3.select(window).on('resize', chart.resize);
     </script>
 </body>

--- a/public/chart.css
+++ b/public/chart.css
@@ -21,8 +21,7 @@
     cursor: move;
     pointer-events: all;
 }
-
 .episode {
     fill: grey;
-    opacity: 0.3;
+    opacity: 0.2;
 }

--- a/public/chart.css
+++ b/public/chart.css
@@ -21,3 +21,8 @@
     cursor: move;
     pointer-events: all;
 }
+
+.episode {
+    fill: grey;
+    opacity: 0.3;
+}

--- a/public/chart.js
+++ b/public/chart.js
@@ -1,10 +1,15 @@
 // function to parse string in the format 2006-01-02 to JavaScript's Date type
 var parseDate = d3.time.format("%Y-%m-%d").parse;
 
-function characterChart(svg, dataURL) {
+function characterChart(svg, dataURL, episodesURL) {
+    var self = this;
+    this.fullYdomain = [];
+    this.fullXdomain = [];
+    this.zoom = null;
+
     // set margin
     var margin = {
-        top: 20,
+        top: 40,
         right: 20,
         bottom: 50,
         left: 50
@@ -22,41 +27,52 @@ function characterChart(svg, dataURL) {
     }
 
     // define axis
-    var x = d3.time.scale(),
-        y = d3.scale.linear();
+    var x = d3.time.scale()
+        .range([0, getSize().width]),
+        y = d3.scale.linear()
+        .range([getSize().height, 0]);
+
     var xAxis = d3.svg.axis().scale(x).orient("bottom"),
         yAxis = d3.svg.axis().scale(y).orient("left");
 
+    // Seperate axis for episodes
+    var eAxis = d3.svg.axis().scale(x).orient("top");
+
+    // TODO: Improve Multi-Scale Tick Format on time x-axis
+    // Cheat sheet: https://github.com/mbostock/d3/wiki/Time-Formatting#format_iso
+    /*    var customTimeFormat = d3.time.format.multi([
+            [".%L", function(d) { return d.getMilliseconds(); }],
+            [":%S", function(d) { return d.getSeconds(); }],
+            ["%I:%M", function(d) { return d.getMinutes(); }],
+            ["%I %p", function(d) { return d.getHours(); }],
+            ["%a %d", function(d) { return d.getDay() && d.getDate() != 1; }],
+            ["%b %d", function(d) { return d.getDate() != 1; }],
+            ["%B", function(d) { return d.getMonth(); }],
+            ["%Y", function() { return true; }]
+        ]);
+        xAxis.tickFormat(customTimeFormat);*/
+
     // positive area between x-axis at y=0 and max(y)
-    var calcAreaPos = d3.svg.area().interpolate("monotone").x(function (d) {
-        return x(d.date);
-    }).y0(function (d) {
-        return y(0);
-    }).y1(function (d) {
-        return y(d.pos);
-    });
+    var calcAreaPos = d3.svg.area()
+        //.interpolate("monotone")
+        .x(function (d) {
+            return x(d.date);
+        }).y0(function (d) {
+            return y(0);
+        }).y1(function (d) {
+            return y(d.pos);
+        });
 
     // negative area between x-axis at y=0 and min(y)
-    var calcAreaNeg = d3.svg.area().interpolate("monotone").x(function (d) {
-        return x(d.date);
-    }).y0(function (d) {
-        return y(d.neg);
-    }).y1(function (d) {
-        return y(0);
-    });
-
-    /*
-    DOM Tree
-    
-    svg
-        container
-            plot
-                chart
-            x axis
-            y axis
-        
-        More charts?
-    */
+    var calcAreaNeg = d3.svg.area()
+        //.interpolate("monotone")
+        .x(function (d) {
+            return x(d.date);
+        }).y0(function (d) {
+            return y(d.neg);
+        }).y1(function (d) {
+            return y(0);
+        });
 
     // Outer container for the timeline
     var container = svg.append("g")
@@ -70,8 +86,9 @@ function characterChart(svg, dataURL) {
         .attr("id", "background")
         .attr("class", "react")
         .attr("width", getSize().width - 1)
-        .attr("height", getSize().height)
+        .attr("height", getSize().height - 1)
         .attr("x", "1")
+        .attr("y", "1")
         .style("fill", "#EEEEEE");
     // Moving to the right by 1px to prevent shadowing of y axis.
 
@@ -100,14 +117,23 @@ function characterChart(svg, dataURL) {
     var xLabel = container.append("g").attr("class", "x axis")
         .attr("transform", "translate(0," + getSize().height + ")"),
         yLabel = container.append("g").attr("class", "y axis");
+    var eLabel = container.append("g").attr("class", "x axis");
 
-
-    function convertCSV(d) {
+    function convertTwitterCSV(d) {
         // convert string data from CSV
         return {
             date: parseDate(d.date), // parse date column to Date
             pos: +d.pos, // convert pos column to positive number
             neg: -d.neg // convert neg column to negative number
+        };
+    }
+
+    function convertEpisodesCSV(d) {
+        // convert string data from CSV
+        return {
+            date: parseDate(d.date.substring(0, 10)),
+            code: d.code,
+            title: d.title
         };
     }
 
@@ -118,38 +144,78 @@ function characterChart(svg, dataURL) {
             throw up;
         }
 
-        // axis
-        x.range([0, getSize().width]);
-        y.range([getSize().height, 0]);
-
         // set domains (data)
-        // Show all the available data. 
-        /*      x.domain(d3.extent(data, function (d) {
-                    return d.date;
-                }));*/
-        // Show default date range. Could for example be set to the current week. For now test values
-        var minDate = new Date(2016, 1, 20),
-            maxDate = new Date(2016, 3, 5);
-        x.domain([minDate, maxDate]);
+        self.fullXdomain = d3.extent(data, function (d) {
+            return d.date;
+        });
+        // Show all the available data.         
+        x.domain(self.fullXdomain);
+
+        // Show default date range. Could for example be set to the current week. Currently not in use.
+        /*        var minDate = new Date(2016, 1, 20),
+                    maxDate = new Date(2016, 2, 5);
+                x.domain([minDate, maxDate]);*/
 
         // y from min(neg) to max(pos)
         y.domain([d3.min(data, function (d) {
-            return d.neg;
+            return Math.min(-5, d.neg * 1.05); // I like my headroom. Minimum domain = [-5;+5], always at least 5% headroom
         }), d3.max(data, function (d) {
-            return d.pos;
+            return Math.max(5, d.pos * 1.05);
         })]);
+        //y.nice();
+        self.fullYdomain = y.domain();
 
         // set area data
         pos.datum(data);
         neg.datum(data);
 
         // Zoom Handling
-        d3.selectAll(".react").call(d3.behavior.zoom()
+        var currentDomain = x.domain()[1] - x.domain()[0],
+            minScale = currentDomain / (self.fullXdomain[1] - self.fullXdomain[0]),
+            maxScale = Infinity; // TODO: Set meaningful value.
+
+        self.zoom = d3.behavior.zoom()
             .x(x)
-            .scaleExtent([0.1, 10]) // TODO: Set meaningful values
-            .on("zoom", recalc));
+            // .xExtent(fullXdomain) Unfortunately not implemented in current d3js version :(
+            .scaleExtent([minScale, maxScale])
+            .on("zoom", zoomed);
+        d3.selectAll(".react").call(zoom);
 
         render();
+    }
+
+    function episodeLabels(error, data) {
+        // TODO: better error handling
+        if (!!error) {
+            var up = error;
+            throw up;
+        }
+
+        // Create episode "lines" in graph
+        plot.selectAll("bar")
+            .data(data)
+            .enter().append("rect")
+            .attr("class", "episode")
+            .attr("clip-path", "url(#clip)")
+            .attr("x", function (d) {
+                return x(d.date);
+            })
+            .attr("y", 0)
+            .attr("width", 1)
+            .attr("height", getSize().height);
+
+        eAxis.tickValues(function () {
+            var a = [];
+            for (var d of data) {
+                a.push(d.date);
+            }
+            return a;
+        });
+        eAxis.tickFormat(function (d, i) {
+            return data[i].code;
+        });
+
+        eLabel.call(eAxis);
     }
 
     function render() {
@@ -161,18 +227,39 @@ function characterChart(svg, dataURL) {
         recalc();
     }
 
+    function zoomed() {
+        // Workaround because .xExtent() for the zoom behaviour is not part of the current official d3js release
+        if (x.domain()[0] < fullXdomain[0]) {
+            zoom.translate([zoom.translate()[0] - x(fullXdomain[0]) + x.range()[0], 0]);
+        } else if (x.domain()[1] > fullXdomain[1]) {
+            zoom.translate([zoom.translate()[0] - x(fullXdomain[1]) + x.range()[1], 0]);
+        }
+
+        recalc();
+    }
+
     function recalc() {
         // areas
         pos.attr("d", calcAreaPos);
         neg.attr("d", calcAreaNeg);
 
+        // episode labels
+        d3.selectAll(".episode")
+            .attr("x", function (d) {
+                return x(d.date);
+            });
+
         // axis
         xLabel.call(xAxis);
         yLabel.call(yAxis);
+        eLabel.call(eAxis);
     }
 
-    // request csv data and fill chart
-    d3.csv(dataURL, convertCSV, fillChart);
+    // request csv twitter data and fill chart
+    d3.csv(dataURL, convertTwitterCSV, fillChart);
+
+    // request csv episodes data and create episode labels
+    d3.csv(episodesURL, convertEpisodesCSV, episodeLabels)
 
     this.resize = render;
 


### PR DESCRIPTION
Replaces pull request #82. Working on #71.

**Provided functionality:**
- Start on time-range with data. Prevent zooming / panning out of our data-range.
- Mark episode airing dates on the x-axis
- detect CSV path prefix (not always /csv, depends on the implementation) from original passed CSV path

Also fixes old zooming & panning bugs. 

**Known issues:**
- Overlapping airing dates / episodes on the x-axis: Normally there's at least a week between episodes, then the code works just fine. Unfortunately, some episodes are saved with the wrong airing dates [#123](https://github.com/Rostlab/JS16_ProjectA/issues/123). Waiting for Project A fix.

Please review & merge :)
